### PR TITLE
[stable/efs-provisioner] Allow passing in annotations via values

### DIFF
--- a/stable/efs-provisioner/Chart.yaml
+++ b/stable/efs-provisioner/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: efs-provisioner
 description: A Helm chart for the AWS EFS external storage provisioner
-version: 0.1.2
+version: 0.1.3
 appVersion: v0.1.2
 home: https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs
 sources:

--- a/stable/efs-provisioner/README.md
+++ b/stable/efs-provisioner/README.md
@@ -68,6 +68,10 @@ busyboxImage:
   tag: 1.27
   pullPolicy: IfNotPresent
 
+## Deployment annotations
+##
+annotations: {}
+
 ## Configure provisioner
 ## https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs#deployment
 ##

--- a/stable/efs-provisioner/templates/clusterrole.yaml
+++ b/stable/efs-provisioner/templates/clusterrole.yaml
@@ -9,6 +9,8 @@ metadata:
     chart: {{ template "efs-provisioner.chartname" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+{{ toYaml .Values.annotations | indent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]

--- a/stable/efs-provisioner/templates/clusterrolebinding.yaml
+++ b/stable/efs-provisioner/templates/clusterrolebinding.yaml
@@ -9,6 +9,8 @@ metadata:
     chart: {{ template "efs-provisioner.chartname" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+{{ toYaml .Values.annotations | indent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "efs-provisioner.serviceAccountName" . }}

--- a/stable/efs-provisioner/templates/deployment.yaml
+++ b/stable/efs-provisioner/templates/deployment.yaml
@@ -19,6 +19,8 @@ metadata:
     chart: {{ template "efs-provisioner.chartname" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+{{ toYaml .Values.annotations | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -33,6 +35,8 @@ spec:
       labels:
         app: {{ template "efs-provisioner.name" . }}
         release: "{{ .Release.Name }}"
+      annotations:
+{{ toYaml .Values.annotations | indent 8 }}
     spec:
       serviceAccount: {{ template "efs-provisioner.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}

--- a/stable/efs-provisioner/templates/serviceaccount.yaml
+++ b/stable/efs-provisioner/templates/serviceaccount.yaml
@@ -9,4 +9,6 @@ metadata:
     chart: {{ template "efs-provisioner.chartname" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+{{ toYaml .Values.annotations | indent 4 }}
 {{- end }}

--- a/stable/efs-provisioner/templates/storageclass.yaml
+++ b/stable/efs-provisioner/templates/storageclass.yaml
@@ -11,6 +11,7 @@ metadata:
 {{- if .Values.efsProvisioner.storageClass.isDefault }}
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
+{{ toYaml .Values.annotations | indent 4 }}
 {{- end }}
 provisioner: {{ .Values.efsProvisioner.provisionerName }}
 parameters:


### PR DESCRIPTION
#### What this PR does / why we need it:

This commit enables passing in annotations via values for the
`efs-provisioner` chart and bumps the version to 0.1.3

Signed-off-by: Josh Myers <joshuajmyers@gmail.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
